### PR TITLE
Remove usage of eslint-recommended

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
   ],


### PR DESCRIPTION
The config `eslint-recommended` is used to modify `eslint:recommended` to support TypeScript better.

As indicated in https://typescript-eslint.io/linting/configs#eslint-recommended, it is included in the other recommended configurations, and so we can follow the advice not to use it directly.