### PR TITLE
Revert Typescript peer dependency change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pgateway/eslint-config-base",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pgateway/eslint-config-base",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.4.1",
@@ -24,7 +24,7 @@
         "eslint-plugin-jsx-a11y": ">=6",
         "eslint-plugin-react": ">=7",
         "eslint-plugin-react-hooks": ">=4",
-        "typescript": ">=4"
+        "typescript": "*"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgateway/eslint-config-base",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "pgateway base eslint config",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "eslint": ">=7",
     "@typescript-eslint/eslint-plugin": ">=4",
     "@typescript-eslint/parser": ">=4",
-    "typescript": ">=4",
+    "typescript": "*",
     "eslint-plugin-jsx-a11y": ">=6",
     "eslint-plugin-react": ">=7",
     "eslint-plugin-react-hooks": ">=4"


### PR DESCRIPTION
Keep it as `*` for now. Once issue is resolved we should revert to a stricter dependency.