### PR TITLE
Restrict peer dependency for ESLint to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "eslint-plugin-react-hooks": "^4.2.0"
   },
   "peerDependencies": {
-    "eslint": ">=7",
+    "eslint": "^7",
     "@typescript-eslint/eslint-plugin": ">=4",
     "@typescript-eslint/parser": ">=4",
-    "typescript": "*",
+    "typescript": ">=4",
     "eslint-plugin-jsx-a11y": ">=6",
     "eslint-plugin-react": ">=7",
     "eslint-plugin-react-hooks": ">=4"


### PR DESCRIPTION
As per the advice of @edward-s.

Since ESLint v7 to v8 is potentially breaking, we changed peer dependency to `^7` instead of `>=7`. A `^8` version will be created separately. This help to better protect against unintended breaking changes in repos that depend on this package.

Also, took the chance to revert-revert Typescript to `>=4` (previously reverted in #6). Since this is found to be a breaking change, we should increase the major version if this PR gets accepted.